### PR TITLE
Refactor shared code

### DIFF
--- a/client/Makefile
+++ b/client/Makefile
@@ -47,14 +47,20 @@ OBJ = $(SRC:.c=.o)
 
 # Headers
 LOCAL_INCLUDE = ./include/
+
+SHARED_LIBRARY = ./lib/chat.a
+SHARED_SRC = ../lib/chat.c
 SHARED_INCLUDE = ../include/
 
 all: reset $(TARGET) clean
 
 # Link
-$(TARGET): $(OBJ) | bin
-	$(CC) $(CFLAGS) $(OBJ) $(RAYLIB) -o $(TARGET) -lm  -I$(SHARED_INCLUDE) -I$(LOCAL_INCLUDE)
+$(TARGET): $(SHARED_LIBRARY) $(OBJ) | bin
+	$(CC) $(CFLAGS) $(OBJ) $(SHARED_LIBRARY) $(RAYLIB) -o $(TARGET) -lm  -I$(SHARED_INCLUDE) -I$(LOCAL_INCLUDE)
 	rm -f $(OBJ)
+
+$(SHARED_LIBRARY): $(SHARED_SRC)
+	$(CC) $(CFLAGS) -c $< -o $@ -I $(SHARED_INCLUDE)
 
 # Compile
 %.o: %.c
@@ -70,6 +76,6 @@ reset:
 	rm -rf bin
 
 clean:
-	rm -f $(OBJ)
+	rm -f $(OBJ) $(SHARED_LIBRARY)
 
 .PHONY: all run_client clean reset

--- a/client/src/client.c
+++ b/client/src/client.c
@@ -117,7 +117,7 @@ static int start_cli(int socket_fd) {
         if (!destination_received)
             printf("\n\t[CLIENT] Server messsage received first\n");
 
-        Message m = unpack_message(socket_fd);
+        Message m = receive_message(socket_fd);
 
         if (m.type == DISCONNECT) {
             printf("[Client] Server has disconnected\n");

--- a/include/chat.h
+++ b/include/chat.h
@@ -12,7 +12,6 @@
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
-#include <errno.h>
 
 #define PORT 8080
 #define MAX_MSG_LEN 4096
@@ -49,7 +48,7 @@ typedef struct {
     // Readable Ip Source
 } ClientMessage;
 
-typedef enum { MESSAGE, INVALID, DISCONNECT } MessageType;
+typedef enum { MESSAGE = 1, INVALID = -1, DISCONNECT = 0} MessageType;
 
 typedef struct {
     MessageType type;
@@ -77,6 +76,16 @@ typedef enum {
     INTERRUPT,
 } SignalResponse;
 
+int create_socket(void);
+
+struct sockaddr_in configure_socket(void);
+
+// Send a HEADER prefixed message
+ssize_t send_message(int fd, const ClientMessage* message);
+
+// Receive a message
+Message receive_message(int fd);
+
 Connections init_connections(void);
 
 void deinit_connections(Connections* connections);
@@ -88,21 +97,9 @@ bool reactivate_connection(Connections* connections, Connection incoming);
 // Shutdown flag for signal handling
 extern volatile sig_atomic_t running;
 
-inline void kill_sig(int sig);
+void kill_sig(int sig);
 
-inline void setup_signal_handler(void);
-
-// Pack a message with length prefix, returns total bytes to send
-inline ssize_t pack_message(const ClientMessage* message, char* out_buf, size_t buf_size);
-
-inline Message unpack_message(int fd);
-
-// Send a length-prefixed message
-inline ssize_t send_message(int fd, const ClientMessage* message);
-
-int create_socket(void);
-
-struct sockaddr_in configure_socket(void);
+void setup_signal_handler(void);
 
 SignalResponse is_signal_ready(int max_fd, fd_set* read_fds);
 

--- a/include/chat.h
+++ b/include/chat.h
@@ -44,8 +44,6 @@ typedef struct {
 
     // Holds destination when type is send, holds source when type is receive
     char ip[INET_ADDRSTRLEN];
-
-    // Readable Ip Source
 } ClientMessage;
 
 typedef enum { MESSAGE = 1, INVALID = -1, DISCONNECT = 0} MessageType;

--- a/include/chat.h
+++ b/include/chat.h
@@ -71,214 +71,39 @@ typedef struct {
     size_t cap;
 } Connections;
 
-static Connections init_connections(void) {
-    return (Connections) {
-        .data = malloc(sizeof(Connection) * MAX_CONNECTIONS),
-        .len = 0,
-        .cap = MAX_CONNECTIONS,
-    };
-}
-
-static void deinit_connections(Connections* connections) {
-    free(connections->data);
-    connections->data = NULL;
-    connections->len = 0;
-    connections->cap = 0;
-}
-
-static void add_connection(Connections* connections, Connection connection) {
-    if (connections->len == connections->cap) {
-        Connection* old_data = connections->data;
-
-        connections->cap *= 2;
-        connections->data = malloc(sizeof(Connection) * connections->cap);
-        memcpy(connections->data, old_data, connections->len * sizeof(Connection));
-        free(old_data);
-    }
-
-    connections->data[connections->len++] = connection;
-}
-
-static bool reactivate_connection(Connections* connections, Connection incoming) {
-    for (size_t i = 0; i < connections->len; i++) {
-        Connection* existing = &connections->data[i];
-
-        if (existing->active)
-            continue;
-
-        if (strcmp(existing->ip, incoming.ip) == 0) {
-            *existing = incoming;
-
-            return true;
-        }
-    }
-    return false;
-}
-
-// Shutdown flag for signal handling
-extern volatile sig_atomic_t running;
-
-static inline void kill_sig(int sig) {
-    (void)sig;
-    running = 0;
-}
-
-static inline void setup_signal_handler(void) {
-    struct sigaction sa;
-    sa.sa_handler = kill_sig;
-    sa.sa_flags = 0;
-    sigemptyset(&sa.sa_mask);
-    sigaction(SIGINT, &sa, NULL);
-}
-
-// Pack a message with length prefix, returns total bytes to send
-static inline ssize_t pack_message(const ClientMessage* message, char* out_buf, size_t buf_size) {
-    if (message->content.len + HEADER_SIZE > buf_size)
-        return -1; // msg too big
-
-    char type[HEADER_TYPE_SIZE] = { MESSAGE };
-    memcpy(out_buf, type, HEADER_TYPE_SIZE);
-    memcpy(out_buf + HEADER_TYPE_SIZE, message->ip, HEADER_ADDR_SIZE);
-
-    uint32_t net_len = htonl((unsigned int)message->content.len);
-    memcpy(out_buf + HEADER_SIZE - HEADER_LEN_SIZE, &net_len, HEADER_LEN_SIZE);
-    memcpy(out_buf + HEADER_SIZE, message->content.data, message->content.len);
-
-    return (ssize_t)(message->content.len + HEADER_SIZE);
-}
-
-static inline Message unpack_message(int fd) {
-    printf("\t[DEBUG] Beginning unpack\n");
-    uint32_t net_len;
-    size_t msg_len;
-
-    Message result;
-
-    ssize_t n;
-
-    char type[HEADER_TYPE_SIZE];
-    n = recv(fd, type, HEADER_TYPE_SIZE, 0);
-    if (n == 0) {
-        return (Message) { .type = DISCONNECT };
-    } else if (n < 0) {
-        printf("[DEBUG] Invalid type received\n");
-        return (Message) { .type = INVALID };
-    }
-
-    result.type = (MessageType)*type;
-
-    printf("[DEBUG] Received regular message\n");
-
-    char dest_buf[HEADER_ADDR_SIZE];
-    n = recv(fd, dest_buf, HEADER_ADDR_SIZE, 0);
-    if (n == 0) {
-        return (Message) { .type = DISCONNECT };
-    } else if (n < 0) {
-        perror("[DEBUG] Invalid address received\n");
-        return (Message) { .type = INVALID };
-    }
-
-    if (n < HEADER_ADDR_SIZE) {
-        dest_buf[n] = '\0';
-        printf("[DEBUG] Invalid address received: %s\n", dest_buf);
-        return (Message) { .type = INVALID };
-    }
-
-    printf("[DEBUG] destination address %s received\n", dest_buf);
-
-    // Copy address into receive ClientMessage
-    result.type_data.message = (ClientMessage) { .type = RECEIVE };
-    memcpy(result.type_data.message.ip, dest_buf, HEADER_ADDR_SIZE);
-
-    // Read 4-byte length header
-    n = recv(fd, &net_len, HEADER_LEN_SIZE, 0);
-    if (n == 0) {
-        return (Message) { .type = DISCONNECT };
-    } else if (n < 0) {
-        return (Message) { .type = INVALID };
-    }
-
-    if (n < HEADER_LEN_SIZE)
-        return (Message) { .type = INVALID }; // Incomplete header
-
-    msg_len = ntohl(net_len);
-    if (msg_len <= 0 || msg_len >= MAX_MSG_LEN)
-        return (Message) { .type = INVALID };
-
-    printf("[DEBUG] message length %d received\n", msg_len);
-
-    result.type_data.message.content.len = msg_len;
-    char** msg_data = &result.type_data.message.content.data;
-    *msg_data = malloc(msg_len + 1);
-
-    // Read the actual message
-    ssize_t total = 0;
-    while (total < (ssize_t)msg_len) {
-        n = recv(fd, *msg_data + total, msg_len - (size_t)total, 0);
-        if (n == 0) {
-            free(*msg_data);
-            return (Message) { .type = DISCONNECT };
-        } else if (n < 0) {
-            free(*msg_data);
-            return (Message) { .type = INVALID };
-        }
-        total += n;
-    }
-    (*msg_data)[msg_len] = '\0';
-
-    printf("[DEBUG] message %s received\n", *msg_data);
-
-    return result;
-}
-
-// Send a length-prefixed message
-static inline ssize_t send_message(int fd, const ClientMessage* message) {
-    char packet[MAX_MSG_LEN + HEADER_SIZE];
-    ssize_t total = pack_message(message, packet, sizeof(packet));
-    if (total < 0)
-        return -1;
-
-    ssize_t sent = 0;
-    while (sent < total) {
-        ssize_t n = send(fd, packet + sent, (size_t)(total - sent), 0);
-        if (n <= 0)
-            return n;
-        sent += n;
-    }
-    return sent - HEADER_SIZE; // Payload bytes sent
-}
-
-static int create_socket(void) {
-    int server_fd = socket(AF_INET, SOCK_STREAM, 0);
-    if (server_fd < 0) {
-        perror("[ERROR] Failed to create socket\n");
-        exit(1);
-    }
-    return server_fd;
-}
-
-static struct sockaddr_in configure_socket(void) {
-    struct sockaddr_in addr;
-    addr.sin_family = AF_INET; // Use ipv4
-    addr.sin_port = htons(PORT); // Get port
-    return addr;
-}
-
 typedef enum {
     FD_ERROR,
     SIGNAL,
     INTERRUPT,
 } SignalResponse;
 
-static SignalResponse is_signal_ready(int max_fd, fd_set* read_fds) {
-    if (select(max_fd + 1, read_fds, NULL, NULL, NULL) < 0) {
-        if (errno == EINTR) {
-            return INTERRUPT; // ctrl+C was pressed
-        } else {
-            return FD_ERROR;
-        }
-    }
-    return SIGNAL;
-}
+Connections init_connections(void);
+
+void deinit_connections(Connections* connections);
+
+void add_connection(Connections* connections, Connection connection);
+
+bool reactivate_connection(Connections* connections, Connection incoming);
+
+// Shutdown flag for signal handling
+extern volatile sig_atomic_t running;
+
+inline void kill_sig(int sig);
+
+inline void setup_signal_handler(void);
+
+// Pack a message with length prefix, returns total bytes to send
+inline ssize_t pack_message(const ClientMessage* message, char* out_buf, size_t buf_size);
+
+inline Message unpack_message(int fd);
+
+// Send a length-prefixed message
+inline ssize_t send_message(int fd, const ClientMessage* message);
+
+int create_socket(void);
+
+struct sockaddr_in configure_socket(void);
+
+SignalResponse is_signal_ready(int max_fd, fd_set* read_fds);
 
 #endif

--- a/include/chat.h
+++ b/include/chat.h
@@ -97,8 +97,6 @@ bool reactivate_connection(Connections* connections, Connection incoming);
 // Shutdown flag for signal handling
 extern volatile sig_atomic_t running;
 
-void kill_sig(int sig);
-
 void setup_signal_handler(void);
 
 SignalResponse is_signal_ready(int max_fd, fd_set* read_fds);

--- a/lib/chat.c
+++ b/lib/chat.c
@@ -79,17 +79,17 @@ bool reactivate_connection(Connections* connections, Connection incoming) {
     return false;
 }
 
+static void kill_sig(int sig) {
+    (void)sig;
+    running = 0;
+}
+
 void setup_signal_handler(void) {
     struct sigaction sa;
     sa.sa_handler = kill_sig;
     sa.sa_flags = 0;
     sigemptyset(&sa.sa_mask);
     sigaction(SIGINT, &sa, NULL);
-}
-
-void kill_sig(int sig) {
-    (void)sig;
-    running = 0;
 }
 
 // Pack a message with length prefix, returns total bytes to send

--- a/lib/chat.c
+++ b/lib/chat.c
@@ -1,4 +1,39 @@
 #include <chat.h>
+#include <errno.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+// Shutdown flag for signal handling
+extern volatile sig_atomic_t running;
+
+int create_socket(void) {
+    int server_fd = socket(AF_INET, SOCK_STREAM, 0);
+    if (server_fd < 0) {
+        perror("[ERROR] Failed to create socket\n");
+        exit(1);
+    }
+    return server_fd;
+}
+
+struct sockaddr_in configure_socket(void) {
+    struct sockaddr_in addr;
+    addr.sin_family = AF_INET; // Use ipv4
+    addr.sin_port = htons(PORT); // Get port
+    return addr;
+}
+
+SignalResponse is_signal_ready(int max_fd, fd_set* read_fds) {
+    if (select(max_fd + 1, read_fds, NULL, NULL, NULL) < 0) {
+        if (errno == EINTR) {
+            return INTERRUPT; // ctrl+C was pressed
+        } else {
+            return FD_ERROR;
+        }
+    }
+    return SIGNAL;
+}
 
 Connections init_connections(void) {
     return (Connections) {
@@ -44,15 +79,7 @@ bool reactivate_connection(Connections* connections, Connection incoming) {
     return false;
 }
 
-// Shutdown flag for signal handling
-extern volatile sig_atomic_t running;
-
-inline void kill_sig(int sig) {
-    (void)sig;
-    running = 0;
-}
-
-inline void setup_signal_handler(void) {
+void setup_signal_handler(void) {
     struct sigaction sa;
     sa.sa_handler = kill_sig;
     sa.sa_flags = 0;
@@ -60,8 +87,13 @@ inline void setup_signal_handler(void) {
     sigaction(SIGINT, &sa, NULL);
 }
 
+void kill_sig(int sig) {
+    (void)sig;
+    running = 0;
+}
+
 // Pack a message with length prefix, returns total bytes to send
-inline ssize_t pack_message(const ClientMessage* message, char* out_buf, size_t buf_size) {
+static ssize_t pack_message(const ClientMessage* message, char* out_buf, size_t buf_size) {
     if (message->content.len + HEADER_SIZE > buf_size)
         return -1; // msg too big
 
@@ -76,92 +108,8 @@ inline ssize_t pack_message(const ClientMessage* message, char* out_buf, size_t 
     return (ssize_t)(message->content.len + HEADER_SIZE);
 }
 
-inline Message unpack_message(int fd) {
-    printf("\t[DEBUG] Beginning unpack\n");
-    uint32_t net_len;
-    size_t msg_len;
-
-    Message result;
-
-    ssize_t n;
-
-    char type[HEADER_TYPE_SIZE];
-    n = recv(fd, type, HEADER_TYPE_SIZE, 0);
-    if (n == 0) {
-        return (Message) { .type = DISCONNECT };
-    } else if (n < 0) {
-        printf("[DEBUG] Invalid type received\n");
-        return (Message) { .type = INVALID };
-    }
-
-    result.type = (MessageType)*type;
-
-    printf("[DEBUG] Received regular message\n");
-
-    char dest_buf[HEADER_ADDR_SIZE];
-    n = recv(fd, dest_buf, HEADER_ADDR_SIZE, 0);
-    if (n == 0) {
-        return (Message) { .type = DISCONNECT };
-    } else if (n < 0) {
-        perror("[DEBUG] Invalid address received\n");
-        return (Message) { .type = INVALID };
-    }
-
-    if (n < HEADER_ADDR_SIZE) {
-        dest_buf[n] = '\0';
-        printf("[DEBUG] Invalid address received: %s\n", dest_buf);
-        return (Message) { .type = INVALID };
-    }
-
-    printf("[DEBUG] destination address %s received\n", dest_buf);
-
-    // Copy address into receive ClientMessage
-    result.type_data.message = (ClientMessage) { .type = RECEIVE };
-    memcpy(result.type_data.message.ip, dest_buf, HEADER_ADDR_SIZE);
-
-    // Read 4-byte length header
-    n = recv(fd, &net_len, HEADER_LEN_SIZE, 0);
-    if (n == 0) {
-        return (Message) { .type = DISCONNECT };
-    } else if (n < 0) {
-        return (Message) { .type = INVALID };
-    }
-
-    if (n < HEADER_LEN_SIZE)
-        return (Message) { .type = INVALID }; // Incomplete header
-
-    msg_len = ntohl(net_len);
-    if (msg_len <= 0 || msg_len >= MAX_MSG_LEN)
-        return (Message) { .type = INVALID };
-
-    printf("[DEBUG] message length %d received\n", msg_len);
-
-    result.type_data.message.content.len = msg_len;
-    char** msg_data = &result.type_data.message.content.data;
-    *msg_data = malloc(msg_len + 1);
-
-    // Read the actual message
-    ssize_t total = 0;
-    while (total < (ssize_t)msg_len) {
-        n = recv(fd, *msg_data + total, msg_len - (size_t)total, 0);
-        if (n == 0) {
-            free(*msg_data);
-            return (Message) { .type = DISCONNECT };
-        } else if (n < 0) {
-            free(*msg_data);
-            return (Message) { .type = INVALID };
-        }
-        total += n;
-    }
-    (*msg_data)[msg_len] = '\0';
-
-    printf("[DEBUG] message %s received\n", *msg_data);
-
-    return result;
-}
-
 // Send a length-prefixed message
-inline ssize_t send_message(int fd, const ClientMessage* message) {
+ssize_t send_message(int fd, const ClientMessage* message) {
     char packet[MAX_MSG_LEN + HEADER_SIZE];
     ssize_t total = pack_message(message, packet, sizeof(packet));
     if (total < 0)
@@ -177,35 +125,94 @@ inline ssize_t send_message(int fd, const ClientMessage* message) {
     return sent - HEADER_SIZE; // Payload bytes sent
 }
 
-int create_socket(void) {
-    int server_fd = socket(AF_INET, SOCK_STREAM, 0);
-    if (server_fd < 0) {
-        perror("[ERROR] Failed to create socket\n");
-        exit(1);
+// Returns message type if disconnected or invalid or length of message content
+static ssize_t unpack_message(int fd, char buffer[HEADER_SIZE + MAX_MSG_LEN]) {
+    printf("\t[DEBUG] Beginning unpack\n");
+    ssize_t msg_len;
+
+    ssize_t n;
+
+    n = recv(fd, buffer, HEADER_TYPE_SIZE, 0);
+    if (n == 0) {
+        return DISCONNECT;
+    } else if (n < 0) {
+        printf("[DEBUG] Invalid type received\n");
+        return INVALID;
     }
-    return server_fd;
-}
 
-struct sockaddr_in configure_socket(void) {
-    struct sockaddr_in addr;
-    addr.sin_family = AF_INET; // Use ipv4
-    addr.sin_port = htons(PORT); // Get port
-    return addr;
-}
+    printf("[DEBUG] Received regular message\n");
 
-typedef enum {
-    FD_ERROR,
-    SIGNAL,
-    INTERRUPT,
-} SignalResponse;
+    n = recv(fd, buffer + HEADER_TYPE_SIZE, HEADER_ADDR_SIZE, 0);
+    if (n == 0) {
+        return DISCONNECT;
+    } else if (n < 0) {
+        perror("[DEBUG] Invalid address received\n");
+        return INVALID;
+    }
 
-SignalResponse is_signal_ready(int max_fd, fd_set* read_fds) {
-    if (select(max_fd + 1, read_fds, NULL, NULL, NULL) < 0) {
-        if (errno == EINTR) {
-            return INTERRUPT; // ctrl+C was pressed
-        } else {
-            return FD_ERROR;
+    if (n < HEADER_ADDR_SIZE) {
+        (buffer + HEADER_TYPE_SIZE)[n] = '\0';
+        printf("[DEBUG] Invalid address received: %s\n", buffer + HEADER_TYPE_SIZE);
+        return INVALID;
+    }
+
+    printf("[DEBUG] destination address %s received\n", buffer + HEADER_TYPE_SIZE);
+
+    // Read 4-byte length header
+    uint32_t net_len;
+    n = recv(fd, &net_len, HEADER_LEN_SIZE, 0);
+    if (n == 0) {
+        return DISCONNECT;
+    } else if (n < 0) {
+        return INVALID;
+    }
+
+    if (n < HEADER_LEN_SIZE)
+        return INVALID; // Incomplete header
+
+    msg_len = ntohl(net_len);
+    if (msg_len <= 0 || msg_len >= MAX_MSG_LEN)
+        return INVALID;
+
+    printf("[DEBUG] message length %d received\n", msg_len);
+
+    char* msg_data = (buffer + HEADER_SIZE);
+
+    // Read the actual message
+    ssize_t total = 0;
+    while (total < msg_len) {
+        n = recv(fd, msg_data + total, (size_t)(msg_len - total), 0);
+        if (n == 0) {
+            return DISCONNECT;
+        } else if (n < 0) {
+            return INVALID;
         }
+        total += n;
     }
-    return SIGNAL;
+    msg_data[msg_len] = '\0';
+
+    return msg_len;
+}
+
+Message receive_message(int fd) {
+    char buffer[MAX_MSG_LEN + HEADER_SIZE];
+    ssize_t len;
+    switch (len = unpack_message(fd, buffer)) {
+    case INVALID:
+        return (Message) { .type = INVALID };
+    case DISCONNECT:
+        return (Message) { .type = DISCONNECT };
+    default:
+        Message result = { .type = MESSAGE };
+        ClientMessage* message = &result.type_data.message;
+        message->type = RECEIVE;
+
+        // Copy address into message
+        memcpy(message->ip, buffer + HEADER_TYPE_SIZE, HEADER_ADDR_SIZE);
+        // Copy message content into message
+        message->content.data = malloc((size_t)len);
+        memcpy(message->content.data, buffer + HEADER_TYPE_SIZE + HEADER_ADDR_SIZE, (size_t)len);
+
+        return result;
+    }
 }

--- a/lib/chat.c
+++ b/lib/chat.c
@@ -1,0 +1,211 @@
+#include <chat.h>
+
+Connections init_connections(void) {
+    return (Connections) {
+        .data = malloc(sizeof(Connection) * MAX_CONNECTIONS),
+        .len = 0,
+        .cap = MAX_CONNECTIONS,
+    };
+}
+
+void deinit_connections(Connections* connections) {
+    free(connections->data);
+    connections->data = NULL;
+    connections->len = 0;
+    connections->cap = 0;
+}
+
+void add_connection(Connections* connections, Connection connection) {
+    if (connections->len == connections->cap) {
+        Connection* old_data = connections->data;
+
+        connections->cap *= 2;
+        connections->data = malloc(sizeof(Connection) * connections->cap);
+        memcpy(connections->data, old_data, connections->len * sizeof(Connection));
+        free(old_data);
+    }
+
+    connections->data[connections->len++] = connection;
+}
+
+bool reactivate_connection(Connections* connections, Connection incoming) {
+    for (size_t i = 0; i < connections->len; i++) {
+        Connection* existing = &connections->data[i];
+
+        if (existing->active)
+            continue;
+
+        if (strcmp(existing->ip, incoming.ip) == 0) {
+            *existing = incoming;
+
+            return true;
+        }
+    }
+    return false;
+}
+
+// Shutdown flag for signal handling
+extern volatile sig_atomic_t running;
+
+inline void kill_sig(int sig) {
+    (void)sig;
+    running = 0;
+}
+
+inline void setup_signal_handler(void) {
+    struct sigaction sa;
+    sa.sa_handler = kill_sig;
+    sa.sa_flags = 0;
+    sigemptyset(&sa.sa_mask);
+    sigaction(SIGINT, &sa, NULL);
+}
+
+// Pack a message with length prefix, returns total bytes to send
+inline ssize_t pack_message(const ClientMessage* message, char* out_buf, size_t buf_size) {
+    if (message->content.len + HEADER_SIZE > buf_size)
+        return -1; // msg too big
+
+    char type[HEADER_TYPE_SIZE] = { MESSAGE };
+    memcpy(out_buf, type, HEADER_TYPE_SIZE);
+    memcpy(out_buf + HEADER_TYPE_SIZE, message->ip, HEADER_ADDR_SIZE);
+
+    uint32_t net_len = htonl((unsigned int)message->content.len);
+    memcpy(out_buf + HEADER_SIZE - HEADER_LEN_SIZE, &net_len, HEADER_LEN_SIZE);
+    memcpy(out_buf + HEADER_SIZE, message->content.data, message->content.len);
+
+    return (ssize_t)(message->content.len + HEADER_SIZE);
+}
+
+inline Message unpack_message(int fd) {
+    printf("\t[DEBUG] Beginning unpack\n");
+    uint32_t net_len;
+    size_t msg_len;
+
+    Message result;
+
+    ssize_t n;
+
+    char type[HEADER_TYPE_SIZE];
+    n = recv(fd, type, HEADER_TYPE_SIZE, 0);
+    if (n == 0) {
+        return (Message) { .type = DISCONNECT };
+    } else if (n < 0) {
+        printf("[DEBUG] Invalid type received\n");
+        return (Message) { .type = INVALID };
+    }
+
+    result.type = (MessageType)*type;
+
+    printf("[DEBUG] Received regular message\n");
+
+    char dest_buf[HEADER_ADDR_SIZE];
+    n = recv(fd, dest_buf, HEADER_ADDR_SIZE, 0);
+    if (n == 0) {
+        return (Message) { .type = DISCONNECT };
+    } else if (n < 0) {
+        perror("[DEBUG] Invalid address received\n");
+        return (Message) { .type = INVALID };
+    }
+
+    if (n < HEADER_ADDR_SIZE) {
+        dest_buf[n] = '\0';
+        printf("[DEBUG] Invalid address received: %s\n", dest_buf);
+        return (Message) { .type = INVALID };
+    }
+
+    printf("[DEBUG] destination address %s received\n", dest_buf);
+
+    // Copy address into receive ClientMessage
+    result.type_data.message = (ClientMessage) { .type = RECEIVE };
+    memcpy(result.type_data.message.ip, dest_buf, HEADER_ADDR_SIZE);
+
+    // Read 4-byte length header
+    n = recv(fd, &net_len, HEADER_LEN_SIZE, 0);
+    if (n == 0) {
+        return (Message) { .type = DISCONNECT };
+    } else if (n < 0) {
+        return (Message) { .type = INVALID };
+    }
+
+    if (n < HEADER_LEN_SIZE)
+        return (Message) { .type = INVALID }; // Incomplete header
+
+    msg_len = ntohl(net_len);
+    if (msg_len <= 0 || msg_len >= MAX_MSG_LEN)
+        return (Message) { .type = INVALID };
+
+    printf("[DEBUG] message length %d received\n", msg_len);
+
+    result.type_data.message.content.len = msg_len;
+    char** msg_data = &result.type_data.message.content.data;
+    *msg_data = malloc(msg_len + 1);
+
+    // Read the actual message
+    ssize_t total = 0;
+    while (total < (ssize_t)msg_len) {
+        n = recv(fd, *msg_data + total, msg_len - (size_t)total, 0);
+        if (n == 0) {
+            free(*msg_data);
+            return (Message) { .type = DISCONNECT };
+        } else if (n < 0) {
+            free(*msg_data);
+            return (Message) { .type = INVALID };
+        }
+        total += n;
+    }
+    (*msg_data)[msg_len] = '\0';
+
+    printf("[DEBUG] message %s received\n", *msg_data);
+
+    return result;
+}
+
+// Send a length-prefixed message
+inline ssize_t send_message(int fd, const ClientMessage* message) {
+    char packet[MAX_MSG_LEN + HEADER_SIZE];
+    ssize_t total = pack_message(message, packet, sizeof(packet));
+    if (total < 0)
+        return -1;
+
+    ssize_t sent = 0;
+    while (sent < total) {
+        ssize_t n = send(fd, packet + sent, (size_t)(total - sent), 0);
+        if (n <= 0)
+            return n;
+        sent += n;
+    }
+    return sent - HEADER_SIZE; // Payload bytes sent
+}
+
+int create_socket(void) {
+    int server_fd = socket(AF_INET, SOCK_STREAM, 0);
+    if (server_fd < 0) {
+        perror("[ERROR] Failed to create socket\n");
+        exit(1);
+    }
+    return server_fd;
+}
+
+struct sockaddr_in configure_socket(void) {
+    struct sockaddr_in addr;
+    addr.sin_family = AF_INET; // Use ipv4
+    addr.sin_port = htons(PORT); // Get port
+    return addr;
+}
+
+typedef enum {
+    FD_ERROR,
+    SIGNAL,
+    INTERRUPT,
+} SignalResponse;
+
+SignalResponse is_signal_ready(int max_fd, fd_set* read_fds) {
+    if (select(max_fd + 1, read_fds, NULL, NULL, NULL) < 0) {
+        if (errno == EINTR) {
+            return INTERRUPT; // ctrl+C was pressed
+        } else {
+            return FD_ERROR;
+        }
+    }
+    return SIGNAL;
+}

--- a/server/Makefile
+++ b/server/Makefile
@@ -34,22 +34,31 @@ IP_ADDRESS ?= 127.0.0.1
 # Source files
 SERVER_SRC = src/server.c
 
-# Headers
-LOCAL_INCLUDE = ./include/
+SHARED_LIBRARY = ./lib/chat.a
+SHARED_SRC = ../lib/chat.c
 SHARED_INCLUDE = ../include/
 
-all: $(SERVER_TARGET) 
+# Headers
+LOCAL_INCLUDE = ./include/
 
-bin/server: $(SERVER_SRC) $(SERVER_HDR) | bin
-	$(CC) $(CFLAGS) -I$(LOCAL_INCLUDE) -I$(SHARED_INCLUDE) -o $@ $(SERVER_SRC)
+all: $(SHARED_LIBRARY) $(SERVER_TARGET) clean
+
+bin/server:$(SHARED_LIBRARY) $(SERVER_SRC) | bin
+	$(CC) $(CFLAGS) $(SERVER_SRC) $(SHARED_LIBRARY) -I$(LOCAL_INCLUDE) -I$(SHARED_INCLUDE) -o $@ 
 
 bin:
 	mkdir -p bin
+
+$(SHARED_LIBRARY): $(SHARED_SRC)
+	$(CC) $(CFLAGS) -c $< -o $@ -I $(SHARED_INCLUDE)
 
 run_server: $(SERVER_TARGET)
 	./$(SERVER_TARGET)
 
 clean:
-	rm -rf bin
+	rm -f $(SHARED_LIBRARY)
+	
+reset:
+	rm -rf ./bin/
 
-.PHONY: all run_server clean
+.PHONY: all run_server clean reset

--- a/server/src/server.c
+++ b/server/src/server.c
@@ -184,7 +184,7 @@ static void check_for_messages(Connections* connections, fd_set* read_fds) {
 
         char buf[HEADER_SIZE + MAX_MSG_LEN];
 
-        Message message = unpack_message(connections->data[i].fd);
+        Message message = receive_message(connections->data[i].fd);
         switch (message.type) {
         case INVALID:
             printf("Error: Malinformed Message Received");


### PR DESCRIPTION
The use of static functions in headers was causing compiler warnings to explode and made it more difficult to identify potential failure points. this refactored the header library into a shared library.

Additionally, I added a receive_message function to act as an analogue for send_message function which wraps unpack message